### PR TITLE
SP2-IMX8MP: Update sdk.yml to enable adlink-sp2 configs

### DIFF
--- a/configs/sdk.yml
+++ b/configs/sdk.yml
@@ -59,7 +59,7 @@ BUILD:
 # default kernel config list
 KERNEL_CONFIG:
   ARM64_LS:  "defconfig lsdk.config"
-  ARM64_IMX: "defconfig adlink-sp2.config imx_v8_defconfig"
+  ARM64_IMX: "defconfig imx_v8_defconfig adlink-sp2.config"
   ARM32_LS:  "multi_v7_defconfig multi_v7_lpae.config lsdk.config"
   ARM32_IMX: "imx_v7_defconfig"
 


### PR DESCRIPTION
This commit accomplishes the following:

* Previously, `adlink-sp2.config` was applied to `.config` before `imx_v8_defconfig`. However, since `imx_v8_defconfig` was the last to modify `.config`, it overwrote the changes made by `adlink-sp2.config`.
* This commit resolves the issue by applying `adlink-sp2.config` at the end, ensuring its changes take effect.